### PR TITLE
Propagate SIGPROT faults as a different termination status.

### DIFF
--- a/base/process/kill.h
+++ b/base/process/kill.h
@@ -71,6 +71,10 @@ enum TerminationStatus {
   // On Windows, the OS terminated process due to code integrity failure.
   TERMINATION_STATUS_INTEGRITY_FAILURE,
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+  // CHERI-specific violation caused the process to crash.
+  TERMINATION_STATUS_CHERI_PROT_VIOLATION,
+#endif
   TERMINATION_STATUS_MAX_ENUM
   // clang-format on
 };

--- a/base/process/kill_posix.cc
+++ b/base/process/kill_posix.cc
@@ -51,9 +51,6 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
       case SIGSEGV:
       case SIGTRAP:
       case SIGSYS:
-#if defined(__CHERI_PURE_CAPABILITY__)
-      case SIGPROT:
-#endif   // __CHERI_PURE_CAPABILITY__
         return TERMINATION_STATUS_PROCESS_CRASHED;
       case SIGKILL:
 #if BUILDFLAG(IS_CHROMEOS)
@@ -64,6 +61,10 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
       case SIGINT:
       case SIGTERM:
         return TERMINATION_STATUS_PROCESS_WAS_KILLED;
+#if defined(__CHERI_PURE_CAPABILITY__)
+      case SIGPROT:
+	return TERMINATION_STATUS_CHERI_PROT_VIOLATION;
+#endif   // __CHERI_PURE_CAPABILITY__
       default:
         break;
     }

--- a/chrome/browser/devtools/devtools_ui_bindings.cc
+++ b/chrome/browser/devtools/devtools_ui_bindings.cc
@@ -605,6 +605,9 @@ void DevToolsUIBindings::FrontendWebContentsObserver::
 #if BUILDFLAG(IS_WIN)
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       if (devtools_bindings_->agent_host_.get())
         devtools_bindings_->Detach();
       break;

--- a/chrome/browser/offline_pages/background_loader_offliner.cc
+++ b/chrome/browser/offline_pages/background_loader_offliner.cc
@@ -266,6 +266,9 @@ void BackgroundLoaderOffliner::PrimaryMainFrameRenderProcessGone(
       case base::TERMINATION_STATUS_OOM:
       case base::TERMINATION_STATUS_PROCESS_CRASHED:
       case base::TERMINATION_STATUS_STILL_RUNNING:
+#if defined(__CHERI_PURE_CAPABILITY__)
+      case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
         std::move(completion_callback_)
             .Run(request, Offliner::RequestStatus::LOADING_FAILED_NO_NEXT);
         break;

--- a/chrome/browser/ui/sad_tab.cc
+++ b/chrome/browser/ui/sad_tab.cc
@@ -86,6 +86,9 @@ bool SadTab::ShouldShow(base::TerminationStatus status) {
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
 #endif
     case base::TERMINATION_STATUS_OOM:
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       return true;
     case base::TERMINATION_STATUS_NORMAL_TERMINATION:
     case base::TERMINATION_STATUS_STILL_RUNNING:
@@ -115,6 +118,10 @@ int SadTab::GetTitle() {
     case SAD_TAB_KIND_CRASHED:
     case SAD_TAB_KIND_KILLED:
       return IDS_SAD_TAB_RELOAD_TITLE;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case SAD_TAB_KIND_CHERI_PROT_VIOLATION:
+      return IDS_SAD_TAB_TITLE;
+#endif
   }
   NOTREACHED();
   return 0;
@@ -139,6 +146,10 @@ int SadTab::GetInfoMessage() {
     case SAD_TAB_KIND_KILLED:
       return is_repeatedly_crashing_ ? IDS_SAD_TAB_RELOAD_TRY
                                      : IDS_SAD_TAB_MESSAGE;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case SAD_TAB_KIND_CHERI_PROT_VIOLATION:
+      return IDS_SAD_TAB_CHERI_MESSAGE;
+#endif
   }
   NOTREACHED();
   return 0;
@@ -171,6 +182,9 @@ std::vector<int> SadTab::GetSubMessages() {
       return std::vector<int>();
     case SAD_TAB_KIND_CRASHED:
     case SAD_TAB_KIND_KILLED:
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case SAD_TAB_KIND_CHERI_PROT_VIOLATION:
+#endif
       std::vector<int> message_ids = {IDS_SAD_TAB_RELOAD_RESTART_BROWSER,
                                       IDS_SAD_TAB_RELOAD_RESTART_DEVICE};
       // Only show Incognito suggestion if not already in Incognito mode.
@@ -263,5 +277,10 @@ SadTab::SadTab(content::WebContents* web_contents, SadTabKind kind)
       LOG(WARNING) << "Tab Killed: "
                    << web_contents->GetURL().DeprecatedGetOriginAsURL().spec();
       break;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case SAD_TAB_KIND_CHERI_PROT_VIOLATION:
+      LOG(WARNING) << "Tab Killed as a result of a CHERI fault";
+      break;
+#endif
   }
 }

--- a/chrome/browser/ui/sad_tab_helper.cc
+++ b/chrome/browser/ui/sad_tab_helper.cc
@@ -24,6 +24,10 @@ SadTabKind SadTabKindFromTerminationStatus(base::TerminationStatus status) {
       return SAD_TAB_KIND_KILLED;
     case base::TERMINATION_STATUS_OOM:
       return SAD_TAB_KIND_OOM;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+      return SAD_TAB_KIND_CHERI_PROT_VIOLATION;
+#endif
     default:
       return SAD_TAB_KIND_CRASHED;
   }

--- a/chrome/browser/ui/sad_tab_types.h
+++ b/chrome/browser/ui/sad_tab_types.h
@@ -13,7 +13,10 @@ enum SadTabKind {
   SAD_TAB_KIND_KILLED_BY_OOM,  // Tab killed by oom killer.
 #endif
   SAD_TAB_KIND_OOM,    // Tab ran out of memory.
-  SAD_TAB_KIND_KILLED  // Tab killed.
+  SAD_TAB_KIND_KILLED,  // Tab killed.
+#if defined(__CHERI_PURE_CAPABILITY__)
+  SAD_TAB_KIND_CHERI_PROT_VIOLATION // Tab crashed due to CHERI violation
+#endif
 };
 
 #endif  // CHROME_BROWSER_UI_SAD_TAB_TYPES_H_

--- a/chrome/browser/ui/tabs/tab_renderer_data.cc
+++ b/chrome/browser/ui/tabs/tab_renderer_data.cc
@@ -144,6 +144,9 @@ bool TabRendererData::IsCrashed() const {
           crashed_status ==
               base::TERMINATION_STATUS_PROCESS_WAS_KILLED_BY_OOM ||
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+          crashed_status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
           crashed_status == base::TERMINATION_STATUS_PROCESS_CRASHED ||
           crashed_status == base::TERMINATION_STATUS_ABNORMAL_TERMINATION ||
           crashed_status == base::TERMINATION_STATUS_LAUNCH_FAILED);

--- a/chrome/browser/ui/views/sad_tab_view.cc
+++ b/chrome/browser/ui/views/sad_tab_view.cc
@@ -164,6 +164,11 @@ std::u16string ErrorToString(int error_code) {
     case 140:
       error_string = "SIGSYS";
       break;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case 162:
+      error_string = "SIGPROT";
+      break;
+#endif
     case 258:
       error_string = "WAIT_TIMEOUT";
       break;

--- a/chrome/test/chromedriver/chrome_launcher.cc
+++ b/chrome/test/chromedriver/chrome_launcher.cc
@@ -1201,6 +1201,10 @@ std::string GetTerminationReason(base::TerminationStatus status) {
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
       return "integrity failure";
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+      return "cheri protection failure";
+#endif
     case base::TERMINATION_STATUS_MAX_ENUM:
       NOTREACHED();
       return "max enum";

--- a/chromecast/browser/metrics/cast_stability_metrics_provider.cc
+++ b/chromecast/browser/metrics/cast_stability_metrics_provider.cc
@@ -99,6 +99,9 @@ void CastStabilityMetricsProvider::LogRendererCrash(
     return;
 
   if (status == base::TERMINATION_STATUS_PROCESS_CRASHED ||
+#if defined(__CHERI_PURE_CAPABILITY__)
+      status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
       status == base::TERMINATION_STATUS_ABNORMAL_TERMINATION) {
     ::metrics::StabilityMetricsHelper::RecordStabilityEvent(
         ::metrics::StabilityEventType::kRendererCrash);

--- a/components/discardable_memory/common/discardable_shared_memory_heap.cc
+++ b/components/discardable_memory/common/discardable_shared_memory_heap.cc
@@ -351,7 +351,12 @@ absl::optional<size_t> DiscardableSharedMemoryHeap::GetResidentSize() const {
       // A given span over a piece of Shared Memory (which we will call
       // |shared_memory|) has Span::start_ initialized to a value equivalent
       // to reinterpret_cast<shared_memory->memory()) / block_size_.
+#if defined(__CHERI_PURE_CAPABILITY__)
+      auto temp = free_span->shared_memory()->memory();
+      void* mem = __builtin_cheri_address_set(temp, free_span->start() * block_size_);
+#else   // !__CHERI_PURE_CAPABILITY__
       void* mem = reinterpret_cast<void*>(free_span->start() * block_size_);
+#endif  // !__CHERI_PURE_CAPABILITY__
       absl::optional<size_t> resident_in_span =
           base::trace_event::ProcessMemoryDump::CountResidentBytes(
               mem, free_span->length() * base::GetPageSize());

--- a/components/metrics/stability_metrics_helper.cc
+++ b/components/metrics/stability_metrics_helper.cc
@@ -173,6 +173,9 @@ void StabilityMetricsHelper::LogRendererCrash(bool was_extension_process,
     case base::TERMINATION_STATUS_PROCESS_CRASHED:
     case base::TERMINATION_STATUS_ABNORMAL_TERMINATION:
     case base::TERMINATION_STATUS_OOM:
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       if (was_extension_process) {
 #if !BUILDFLAG(ENABLE_EXTENSIONS)
         NOTREACHED();

--- a/components/new_or_sad_tab_strings.grdp
+++ b/components/new_or_sad_tab_strings.grdp
@@ -109,6 +109,9 @@
           </message>
 	</else>
       </if>
+      <message name="IDS_SAD_TAB_CHERI_MESSAGE" desc="The message displayed on the sad tab page when the renderer crashes due to a CHERI protection violation.">
+	This webpage detected a CHERI memory-safety protection violation and was terminated.
+      </message>
 
       <!-- New Tab -->
       <message name="IDS_NEW_TAB_TITLE"

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -491,6 +491,9 @@ void BrowserChildProcessHostImpl::OnChildDisconnected() {
 #else  // BUILDFLAG(IS_ANDROID)
     switch (info.status) {
       case base::TERMINATION_STATUS_PROCESS_CRASHED:
+#if defined(__CHERI_PURE_CAPABILITY__)
+      case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       case base::TERMINATION_STATUS_ABNORMAL_TERMINATION: {
         exited_abnormally_ = true;
         delegate_->OnProcessCrashed(info.exit_code);

--- a/content/browser/browser_plugin/browser_plugin_guest.cc
+++ b/content/browser/browser_plugin/browser_plugin_guest.cc
@@ -135,6 +135,9 @@ void BrowserPluginGuest::PrimaryMainFrameRenderProcessGone(
     case base::TERMINATION_STATUS_PROCESS_WAS_KILLED:
       RecordAction(base::UserMetricsAction("BrowserPlugin.Guest.Killed"));
       break;
+#if defined(__CHERI_PURE_CAPABILITY__)
+      case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
     case base::TERMINATION_STATUS_PROCESS_CRASHED:
       RecordAction(base::UserMetricsAction("BrowserPlugin.Guest.Crashed"));
       break;

--- a/content/browser/devtools/protocol/target_handler.cc
+++ b/content/browser/devtools/protocol/target_handler.cc
@@ -123,6 +123,10 @@ static std::string TerminationStatusToString(base::TerminationStatus status) {
       return "crashed";
     case base::TERMINATION_STATUS_STILL_RUNNING:
       return "still running";
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+      return "crashed (cheri violation)";
+#endif
 #if BUILDFLAG(IS_CHROMEOS)
     // Used for the case when oom-killer kills a process on ChromeOS.
     case base::TERMINATION_STATUS_PROCESS_WAS_KILLED_BY_OOM:

--- a/content/browser/devtools/render_frame_devtools_agent_host.cc
+++ b/content/browser/devtools/render_frame_devtools_agent_host.cc
@@ -636,6 +636,9 @@ void RenderFrameDevToolsAgentHost::RenderProcessExited(
 #if BUILDFLAG(IS_ANDROID)
     case base::TERMINATION_STATUS_OOM_PROTECTED:
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
     case base::TERMINATION_STATUS_LAUNCH_FAILED:
       for (auto* inspector : protocol::InspectorHandler::ForAgentHost(this))
         inspector->TargetCrashed();

--- a/content/browser/gpu/gpu_process_host.cc
+++ b/content/browser/gpu/gpu_process_host.cc
@@ -200,6 +200,9 @@ GpuTerminationStatus ConvertToGpuTerminationStatus(
     // Treat integrity failure as a crash on Windows.
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       return GpuTerminationStatus::PROCESS_CRASHED;
     case base::TERMINATION_STATUS_STILL_RUNNING:
       return GpuTerminationStatus::STILL_RUNNING;
@@ -777,6 +780,9 @@ GpuProcessHost::~GpuProcessHost() {
 
       if (info.status == base::TERMINATION_STATUS_NORMAL_TERMINATION ||
           info.status == base::TERMINATION_STATUS_ABNORMAL_TERMINATION ||
+#if defined(__CHERI_PURE_CAPABILITY__)
+          info.status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
           info.status == base::TERMINATION_STATUS_PROCESS_CRASHED) {
         // Windows always returns PROCESS_CRASHED on abnormal termination, as it
         // doesn't have a way to distinguish the two.

--- a/content/browser/preloading/prerender/prerender_host_registry.cc
+++ b/content/browser/preloading/prerender/prerender_host_registry.cc
@@ -1366,6 +1366,9 @@ void PrerenderHostRegistry::ResourceLoadComplete(
 void PrerenderHostRegistry::PrimaryMainFrameRenderProcessGone(
     base::TerminationStatus status) {
   CancelAllHosts(
+#if defined(__CHERI_PURE_CAPABILITY__)
+      status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
       status == base::TERMINATION_STATUS_PROCESS_CRASHED
           ? PrerenderFinalStatus::kPrimaryMainFrameRendererProcessCrashed
           : PrerenderFinalStatus::kPrimaryMainFrameRendererProcessKilled);

--- a/content/browser/renderer_host/render_frame_host_impl.cc
+++ b/content/browser/renderer_host/render_frame_host_impl.cc
@@ -3099,6 +3099,9 @@ void RenderFrameHostImpl::RenderProcessGone(
 
   if (IsInBackForwardCache()) {
     EvictFromBackForwardCacheWithReason(
+#if defined(__CHERI_PURE_CAPABILITY__)
+        info.status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
         info.status == base::TERMINATION_STATUS_PROCESS_CRASHED
             ? BackForwardCacheMetrics::NotRestoredReason::
                   kRendererProcessCrashed
@@ -3107,6 +3110,9 @@ void RenderFrameHostImpl::RenderProcessGone(
   }
 
   CancelPrerendering(PrerenderCancellationReason(
+#if defined(__CHERI_PURE_CAPABILITY__)
+      info.status == base::TERMINATION_STATUS_CHERI_PROT_VIOLATION ||
+#endif
       info.status == base::TERMINATION_STATUS_PROCESS_CRASHED
           ? PrerenderFinalStatus::kRendererProcessCrashed
           : PrerenderFinalStatus::kRendererProcessKilled));
@@ -13004,6 +13010,11 @@ void RenderFrameHostImpl::MaybeGenerateCrashReport(
 #endif
       reason = "oom";
       break;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+      reason = "cheri violation";
+      break;
+#endif
     default:
       // Other termination statuses do not indicate a crash.
       return;

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -2263,6 +2263,9 @@ bool WebContentsImpl::IsCrashed() {
 #if BUILDFLAG(IS_WIN)
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+#endif
       return true;
     case base::TERMINATION_STATUS_NORMAL_TERMINATION:
     case base::TERMINATION_STATUS_STILL_RUNNING:

--- a/extensions/browser/guest_view/web_view/web_view_guest.cc
+++ b/extensions/browser/guest_view/web_view/web_view_guest.cc
@@ -161,6 +161,10 @@ static std::string TerminationStatusToString(base::TerminationStatus status) {
     case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
       return "integrity failure";
 #endif
+#if defined(__CHERI_PURE_CAPABILITY__)
+    case base::TERMINATION_STATUS_CHERI_PROT_VIOLATION:
+      return "crashed (cheri violation)";
+#endif
     case base::TERMINATION_STATUS_MAX_ENUM:
       break;
   }


### PR DESCRIPTION
Add CHERI-specific message to the SadTab.